### PR TITLE
bounty: NextJS deployment on Akash with SSL

### DIFF
--- a/BOUNTIES.md
+++ b/BOUNTIES.md
@@ -37,7 +37,7 @@ Bounties related to building decentralized frontend applications for CosmWasm sm
 
 | Task                                              | Description                                                                                                                                                                                 | Reward   | PR  | Claimed by |
 | :------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------- | --- | :--------- |
-| Document deploying a Next.js application on Akash | Document how to deploy a Next.js application on Akash network with HTTPS setup for a custom domain. please include a link to an open source GitHub repo with this documentation in your PR. | 100 JUNO |     |            |
+| Document deploying a Next.js application on Akash | Document how to deploy a Next.js application on Akash network with HTTPS setup for a custom domain. please include a link to an open source GitHub repo with this documentation in your PR. | 100 JUNO |  https://github.com/OIGbash/nextjs-on-akash   |     juno1swq90q58m4rfdq9e9405n7zr69hfm53shfmxcr       |
 
 ## Wallets
 


### PR DESCRIPTION
Hi, 

I made an Akash manifest template and detailed walkthrough instructions for deploying a NextJS application on Akash: https://github.com/OIGbash/nextjs-on-akash

You can see the Akash deployment live here at its assigned URI: http://eg8thju72ldln5juaietlkqpeg.ingress.provider-0.prod.ams1.akash.pub/
And here at my domain with SSL enabled: https://nextjs-akash.com/

The site currently simply links to the directions on Github, but I'd be happy to keep the site live on Akash if desired and develop it into a pretty and user-friendly Akash deployment guide for prospective Cosmwasm smart contract deployers. I would also be happy to create a video walkthrough if that would be helpful. 

Have a great day!